### PR TITLE
Adjust narration line opacity to prevent grey overlay

### DIFF
--- a/400(1)kördiagramm.html
+++ b/400(1)kördiagramm.html
@@ -113,7 +113,7 @@
       left: 0;
       right: 0;
       transform: translateY(0);
-      opacity: 0.62;
+      opacity: 1;
       transition:
         font-size 0.72s cubic-bezier(0.19, 1, 0.22, 1),
         opacity 0.55s ease,
@@ -126,8 +126,8 @@
       word-break: keep-all;
       padding: 0;
     }
-    .step-line.active {
-      opacity: 1;
+    .step-line:not(.active) {
+      opacity: 0.62;
     }
     .step-line.entering {
       opacity: 0;


### PR DESCRIPTION
## Summary
- ensure narration lines render at full opacity by default
- limit dimming effect to non-active narration entries to avoid grey veil on new lines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908c6a5ca208321aacba0d81424b17f